### PR TITLE
Fix LiipImagine deprecation et réinstaller l'extension intl

### DIFF
--- a/backend/config/packages/liip_imagine.yaml
+++ b/backend/config/packages/liip_imagine.yaml
@@ -1,4 +1,6 @@
 liip_imagine:
+    twig:
+        mode: lazy
     driver: gd
     resolvers:
         default:

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -20,9 +20,11 @@ ENV SERVER_NAME=":80"
 
 RUN apk add --no-cache netcat-openbsd
 
-RUN apk add --no-cache libpng-dev libjpeg-turbo-dev libwebp-dev \
+RUN apk add --no-cache --virtual .build-deps libpng-dev libjpeg-turbo-dev libwebp-dev icu-dev \
     && docker-php-ext-configure gd --with-jpeg --with-webp \
-    && docker-php-ext-install pdo_mysql gd
+    && docker-php-ext-install pdo_mysql gd intl \
+    && apk del .build-deps \
+    && apk add --no-cache libpng libjpeg-turbo libwebp icu-libs
 
 WORKDIR /app
 


### PR DESCRIPTION
- Configure liip_imagine.twig.mode=lazy pour supprimer le warning de dépréciation de FilterExtension/FilterTrait (supprimées en 3.0)
- Réinstalle l'extension PHP intl (requise par EasyAdmin pour les champs date/heure)
- Utilise --virtual .build-deps pour ne garder que les libs runtime (icu-libs, libpng, etc.) et réduire la taille de l'image finale + temps de build CI

https://claude.ai/code/session_01AczcW5V8jSRFJg7q4Jwpfy