### PR TITLE
feat: account verification button, random-password reset, error boundary

### DIFF
--- a/backend/src/Controller/Api/AuthApiController.php
+++ b/backend/src/Controller/Api/AuthApiController.php
@@ -145,46 +145,45 @@ final class AuthApiController extends AbstractController
         return ApiResponse::success(null);
     }
 
-    #[Route('/api/auth/reset-password/request', name: 'api_auth_reset_password_request', methods: ['POST'])]
-    public function resetPasswordRequest(Request $request): JsonResponse
+    #[Route('/api/auth/resend-verification', name: 'api_auth_resend_verification', methods: ['POST'])]
+    public function resendVerification(#[CurrentUser] ?User $user, Request $request): JsonResponse
     {
+        if (!$user instanceof User) {
+            return ApiResponse::unauthorized();
+        }
+
+        if ($user->isValidated()) {
+            return ApiResponse::error(
+                new ApiError(ErrorCode::VALIDATION_ERROR, 'Votre compte est déjà validé'),
+                Response::HTTP_UNPROCESSABLE_ENTITY,
+            );
+        }
+
         /** @var array<string, mixed>|null $data */
         $data        = json_decode((string) $request->getContent(), true);
-        $email       = is_array($data) && is_string($data['email'] ?? null) ? $data['email'] : '';
         $callbackUrl = is_array($data) && is_string($data['callbackUrl'] ?? null) ? $data['callbackUrl'] : '';
 
         if ($callbackUrl === '') {
             return ApiResponse::validationError(['callbackUrl' => ['Requis']]);
         }
 
-        $user = $this->authService->findUserByEmail($email);
-
-        if ($user instanceof User) {
-            $this->authService->generateAndSendResetToken($user, $callbackUrl);
-        }
+        $this->userService->sendVerificationEmail($user, $callbackUrl);
 
         return ApiResponse::success(null);
     }
 
-    #[Route('/api/auth/reset-password/confirm', name: 'api_auth_reset_password_confirm', methods: ['POST'])]
-    public function resetPasswordConfirm(Request $request): JsonResponse
+    #[Route('/api/auth/reset-password/request', name: 'api_auth_reset_password_request', methods: ['POST'])]
+    public function resetPasswordRequest(Request $request): JsonResponse
     {
         /** @var array<string, mixed>|null $data */
-        $data     = json_decode((string) $request->getContent(), true);
-        $token    = is_array($data) && is_string($data['token'] ?? null) ? $data['token'] : '';
-        $password = is_array($data) && is_string($data['password'] ?? null) ? $data['password'] : '';
+        $data  = json_decode((string) $request->getContent(), true);
+        $email = is_array($data) && is_string($data['email'] ?? null) ? $data['email'] : '';
 
-        try {
-            $user = $this->authService->validateTokenAndFetchUser($token);
-        } catch (\Exception $exception) {
-            return ApiResponse::error(
-                new ApiError(ErrorCode::VALIDATION_ERROR, $exception->getMessage()),
-                Response::HTTP_UNPROCESSABLE_ENTITY,
-            );
+        $user = $this->authService->findUserByEmail($email);
+
+        if ($user instanceof User) {
+            $this->authService->generateRandomPasswordAndNotify($user);
         }
-
-        $this->authService->removeResetRequest($token);
-        $this->authService->resetPassword($user, $password);
 
         return ApiResponse::success(null);
     }

--- a/backend/src/Service/AuthService.php
+++ b/backend/src/Service/AuthService.php
@@ -10,15 +10,11 @@ use Symfony\Component\Mailer\MailerInterface;
 use Symfony\Component\Mime\Address;
 use Symfony\Component\Mime\Email;
 use Symfony\Component\PasswordHasher\Hasher\UserPasswordHasherInterface;
-use SymfonyCasts\Bundle\ResetPassword\Exception\ResetPasswordExceptionInterface;
-use SymfonyCasts\Bundle\ResetPassword\Model\ResetPasswordToken;
-use SymfonyCasts\Bundle\ResetPassword\ResetPasswordHelperInterface;
 
 final readonly class AuthService
 {
     public function __construct(
         private EntityManagerInterface $entityManager,
-        private ResetPasswordHelperInterface $resetPasswordHelper,
         private UserPasswordHasherInterface $passwordHasher,
         private MailerInterface $mailer,
         private string $mailUser,
@@ -31,47 +27,31 @@ final readonly class AuthService
         return $this->entityManager->getRepository(User::class)->findOneBy(['email' => $email]);
     }
 
-    public function generateAndSendResetToken(User $user, string $callbackUrl): ?ResetPasswordToken
+    public function generateRandomPasswordAndNotify(User $user): void
     {
-        try {
-            $resetToken = $this->resetPasswordHelper->generateResetToken($user);
-        } catch (ResetPasswordExceptionInterface) {
-            return null;
+        $chars    = 'abcdefghijkmnpqrstuvwxyzABCDEFGHJKLMNPQRSTUVWXYZ23456789!@#$%';
+        $password = '';
+        for ($i = 0; $i < 12; ++$i) {
+            $password .= $chars[random_int(0, strlen($chars) - 1)];
         }
 
-        $resetUrl = htmlspecialchars(rtrim($callbackUrl, '/') . '?token=' . $resetToken->getToken(), ENT_QUOTES);
+        $user->setPassword($this->passwordHasher->hashPassword($user, $password));
+        $this->entityManager->flush();
+
+        $safePassword = htmlspecialchars($password, ENT_QUOTES);
 
         $email = new Email()
             ->from(new Address($this->mailUser, $this->mailName))
             ->to((string) $user->getEmail())
-            ->subject('Réinitialisation de votre mot de passe')
+            ->subject('Votre nouveau mot de passe temporaire')
             ->html(
-                '<h1>Bonjour !</h1>' .
-                '<p>Pour réinitialiser votre mot de passe, cliquez sur le lien suivant :</p>' .
-                '<p><a href="' . $resetUrl . '">Réinitialiser mon mot de passe</a></p>'
+                '<h1>Réinitialisation de mot de passe</h1>' .
+                '<p>Votre nouveau mot de passe temporaire est :</p>' .
+                '<p style="font-size:1.4em;font-weight:bold;letter-spacing:2px;">' . $safePassword . '</p>' .
+                '<p>Connectez-vous avec ce mot de passe, puis changez-le depuis votre profil.</p>'
             );
 
         $this->mailer->send($email);
-
-        return $resetToken;
-    }
-
-    public function generateFakeResetToken(): ResetPasswordToken
-    {
-        return $this->resetPasswordHelper->generateFakeResetToken();
-    }
-
-    public function validateTokenAndFetchUser(string $token): User
-    {
-        $user = $this->resetPasswordHelper->validateTokenAndFetchUser($token);
-        assert($user instanceof User);
-
-        return $user;
-    }
-
-    public function removeResetRequest(string $token): void
-    {
-        $this->resetPasswordHelper->removeResetRequest($token);
     }
 
     public function resetPassword(User $user, string $plainPassword): void

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1015,9 +1015,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1035,9 +1032,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1055,9 +1049,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1075,9 +1066,6 @@
         "s390x"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1095,9 +1083,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1115,9 +1100,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1344,9 +1326,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1364,9 +1343,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1384,9 +1360,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1404,9 +1377,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4682,9 +4652,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -4706,9 +4673,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -4730,9 +4694,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -4754,9 +4715,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [

--- a/frontend/src/components/ErrorBoundary.tsx
+++ b/frontend/src/components/ErrorBoundary.tsx
@@ -1,0 +1,54 @@
+import { Component } from 'react';
+import type { ReactNode, ErrorInfo } from 'react';
+
+interface Props {
+  children: ReactNode;
+}
+
+interface State {
+  error: Error | null;
+}
+
+export class ErrorBoundary extends Component<Props, State> {
+  constructor(props: Props) {
+    super(props);
+    this.state = { error: null };
+  }
+
+  static getDerivedStateFromError(error: Error): State {
+    return { error };
+  }
+
+  componentDidCatch(error: Error, info: ErrorInfo) {
+    console.error('[ErrorBoundary]', error, info.componentStack);
+  }
+
+  render() {
+    if (this.state.error !== null) {
+      return (
+        <div className="flex min-h-screen items-center justify-center bg-bg px-6">
+          <div className="max-w-md rounded-2xl border border-line bg-surface p-8 text-center shadow-sm">
+            <div className="mb-4 text-4xl">⚠️</div>
+            <h1 className="mb-2 text-[20px] font-semibold text-ink">
+              Une erreur inattendue s&apos;est produite
+            </h1>
+            <p className="mb-5 text-[14px] leading-relaxed text-ink-2">
+              L&apos;application a rencontré un problème. Si l&apos;erreur persiste, contactez un
+              administrateur en décrivant ce que vous faisiez.
+            </p>
+            <button
+              onClick={() => {
+                window.location.href = '/';
+              }}
+              className="inline-flex h-9 items-center justify-center rounded-[9px] bg-ink px-5 text-sm font-medium text-white transition-opacity hover:opacity-90"
+            >
+              Retour à l&apos;accueil
+            </button>
+          </div>
+        </div>
+      );
+    }
+
+    return this.props.children;
+  }
+}

--- a/frontend/src/lib/api/auth.ts
+++ b/frontend/src/lib/api/auth.ts
@@ -37,10 +37,10 @@ export function verifyEmail(queryString: string): Promise<Result<null>> {
   return get<null>(`/api/auth/verify-email?${queryString}`);
 }
 
-export function requestPasswordReset(email: string, callbackUrl: string): Promise<Result<null>> {
-  return post<null>('/api/auth/reset-password/request', { email, callbackUrl });
+export function requestPasswordReset(email: string): Promise<Result<null>> {
+  return post<null>('/api/auth/reset-password/request', { email });
 }
 
-export function confirmPasswordReset(token: string, password: string): Promise<Result<null>> {
-  return post<null>('/api/auth/reset-password/confirm', { token, password });
+export function resendVerificationEmail(callbackUrl: string): Promise<Result<null>> {
+  return post<null>('/api/auth/resend-verification', { callbackUrl });
 }

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -4,6 +4,7 @@ import { StrictMode } from 'react';
 import { createRoot } from 'react-dom/client';
 import { RouterProvider } from 'react-router';
 import { AuthProvider } from './context/AuthContext';
+import { ErrorBoundary } from './components/ErrorBoundary';
 import { NotificationProvider } from './context/NotificationContext';
 import { queryClient } from './lib/queryClient';
 import { router } from './router';
@@ -16,13 +17,15 @@ if (rootElement === null) {
 
 createRoot(rootElement).render(
   <StrictMode>
-    <QueryClientProvider client={queryClient}>
-      <NotificationProvider>
-        <AuthProvider>
-          <RouterProvider router={router} />
-        </AuthProvider>
-      </NotificationProvider>
-      <ReactQueryDevtools initialIsOpen={false} />
-    </QueryClientProvider>
+    <ErrorBoundary>
+      <QueryClientProvider client={queryClient}>
+        <NotificationProvider>
+          <AuthProvider>
+            <RouterProvider router={router} />
+          </AuthProvider>
+        </NotificationProvider>
+        <ReactQueryDevtools initialIsOpen={false} />
+      </QueryClientProvider>
+    </ErrorBoundary>
   </StrictMode>,
 );

--- a/frontend/src/pages/auth/ResetPasswordPage.tsx
+++ b/frontend/src/pages/auth/ResetPasswordPage.tsx
@@ -1,14 +1,9 @@
 import { useState } from 'react';
-import { useSearchParams } from 'react-router';
-import { requestPasswordReset, confirmPasswordReset } from '../../lib/api/auth';
+import { requestPasswordReset } from '../../lib/api/auth';
 import { Button, Input } from '../../components/ui';
 
 export function ResetPasswordPage() {
-  const [searchParams] = useSearchParams();
-  const token = searchParams.get('token');
-
   const [email, setEmail] = useState('');
-  const [password, setPassword] = useState('');
   const [message, setMessage] = useState<string | null>(null);
   const [error, setError] = useState<string | null>(null);
   const [submitting, setSubmitting] = useState(false);
@@ -17,20 +12,13 @@ export function ResetPasswordPage() {
     setSubmitting(true);
     setError(null);
 
-    if (token !== null) {
-      const result = await confirmPasswordReset(token, password);
-      if (result.ok) {
-        setMessage('Mot de passe modifié. Vous pouvez vous connecter.');
-      } else {
-        setError(result.error.message);
-      }
+    const result = await requestPasswordReset(email);
+    if (result.ok) {
+      setMessage(
+        'Si un compte existe pour cet email, un mot de passe temporaire vous a été envoyé. Connectez-vous avec ce mot de passe et changez-le depuis votre profil.',
+      );
     } else {
-      const result = await requestPasswordReset(email, `${window.location.origin}/reset-password`);
-      if (result.ok) {
-        setMessage('Si un compte existe, un email de réinitialisation a été envoyé.');
-      } else {
-        setError(result.error.message);
-      }
+      setError(result.error.message);
     }
 
     setSubmitting(false);
@@ -38,9 +26,13 @@ export function ResetPasswordPage() {
 
   return (
     <div className="mx-auto max-w-sm px-4 py-16">
-      <h1 className="mb-6 text-[22px] font-semibold tracking-tight text-ink">
-        {token !== null ? 'Nouveau mot de passe' : 'Réinitialiser le mot de passe'}
+      <h1 className="mb-2 text-[22px] font-semibold tracking-tight text-ink">
+        Mot de passe oublié
       </h1>
+      <p className="mb-6 text-[14px] text-ink-3">
+        Renseignez votre email. Vous recevrez un mot de passe temporaire à utiliser pour vous
+        connecter, que vous pourrez ensuite modifier depuis votre profil.
+      </p>
 
       {message !== null && (
         <p className="mb-4 rounded-lg border border-success/20 bg-success/10 px-3 py-2 text-sm text-success">
@@ -53,24 +45,14 @@ export function ResetPasswordPage() {
         </p>
       )}
 
-      <form
-        onSubmit={(e) => {
-          e.preventDefault();
-          void handleSubmit();
-        }}
-        className="flex flex-col gap-3"
-      >
-        {token !== null ? (
-          <Input
-            type="password"
-            placeholder="Nouveau mot de passe"
-            value={password}
-            onChange={(e) => {
-              setPassword(e.target.value);
-            }}
-            required
-          />
-        ) : (
+      {message === null && (
+        <form
+          onSubmit={(e) => {
+            e.preventDefault();
+            void handleSubmit();
+          }}
+          className="flex flex-col gap-3"
+        >
           <Input
             type="email"
             placeholder="Email universitaire"
@@ -80,11 +62,11 @@ export function ResetPasswordPage() {
             }}
             required
           />
-        )}
-        <Button type="submit" size="lg" disabled={submitting} className="mt-1 w-full">
-          {submitting ? 'Envoi…' : 'Envoyer'}
-        </Button>
-      </form>
+          <Button type="submit" size="lg" disabled={submitting} className="mt-1 w-full">
+            {submitting ? 'Envoi…' : 'Envoyer'}
+          </Button>
+        </form>
+      )}
     </div>
   );
 }

--- a/frontend/src/pages/auth/SelectPersonPage.tsx
+++ b/frontend/src/pages/auth/SelectPersonPage.tsx
@@ -3,7 +3,7 @@ import { useNavigate, useLocation, Link } from 'react-router';
 import { register, getAvailablePersons } from '../../lib/api/auth';
 import type { AvailablePerson } from '../../types/auth';
 import { Button, Input } from '../../components/ui';
-import { contrastColor } from '../../lib/colors';
+import { promoColor, contrastColor } from '../../lib/colors';
 import { useNotification } from '../../hooks/useNotification';
 
 const PAGE_SIZE = 20;
@@ -138,8 +138,8 @@ export function SelectPersonPage() {
               <div
                 className="flex h-8 w-8 shrink-0 items-center justify-center rounded-full text-xs font-semibold"
                 style={{
-                  backgroundColor: person.color,
-                  color: contrastColor(person.color),
+                  backgroundColor: promoColor(person.startYear),
+                  color: contrastColor(promoColor(person.startYear)),
                 }}
               >
                 {person.firstName[0]}

--- a/frontend/src/pages/person/PersonPage.tsx
+++ b/frontend/src/pages/person/PersonPage.tsx
@@ -69,9 +69,7 @@ function PersonHero({
   async function handleResendVerification() {
     setVerifying(true);
     setVerifyError(null);
-    const result = await resendVerificationEmail(
-      `${window.location.origin}/verify-email`,
-    );
+    const result = await resendVerificationEmail(`${window.location.origin}/verify-email`);
     if (result.ok) {
       setVerifyDone(true);
     } else {

--- a/frontend/src/pages/person/PersonPage.tsx
+++ b/frontend/src/pages/person/PersonPage.tsx
@@ -1,9 +1,11 @@
+import { useState } from 'react';
 import { useQuery } from '@tanstack/react-query';
 import { Link, useNavigate, useParams } from 'react-router';
 import { Avatar, Breadcrumb, Card, Skeleton, StatCard } from '../../components/ui';
 import { useAuth } from '../../hooks/useAuth';
 import { personQueries } from '../../lib/queries';
 import { promoColor } from '../../lib/colors';
+import { resendVerificationEmail } from '../../lib/api/auth';
 import type { Characteristic, Person } from '../../types/person';
 import { FamilyGraph } from './FamilyGraph';
 
@@ -49,8 +51,35 @@ function CharacteristicChip({ characteristic }: { characteristic: Characteristic
   return inner;
 }
 
-function PersonHero({ person, canEdit }: { person: Person; canEdit: boolean }) {
+function PersonHero({
+  person,
+  canEdit,
+  needsVerification,
+}: {
+  person: Person;
+  canEdit: boolean;
+  needsVerification: boolean;
+}) {
+  const [verifying, setVerifying] = useState(false);
+  const [verifyDone, setVerifyDone] = useState(false);
+  const [verifyError, setVerifyError] = useState<string | null>(null);
+
   const color = promoColor(person.startYear);
+
+  async function handleResendVerification() {
+    setVerifying(true);
+    setVerifyError(null);
+    const result = await resendVerificationEmail(
+      `${window.location.origin}/verify-email`,
+    );
+    if (result.ok) {
+      setVerifyDone(true);
+    } else {
+      setVerifyError(result.error.message);
+    }
+    setVerifying(false);
+  }
+
   return (
     <div className="relative mb-5 overflow-hidden rounded-2xl border border-line bg-surface p-8">
       <div
@@ -96,16 +125,40 @@ function PersonHero({ person, canEdit }: { person: Person; canEdit: boolean }) {
         </div>
 
         {/* Actions */}
-        {canEdit && (
-          <div className="flex flex-col gap-2">
+        <div className="flex flex-col gap-2">
+          {canEdit && (
             <Link
               to={`/person/${person.id}/edit`}
               className="inline-flex h-9 items-center justify-center rounded-[9px] bg-ink px-4 text-sm font-medium text-white transition-all hover:-translate-y-0.5 hover:opacity-90"
             >
               Modifier
             </Link>
-          </div>
-        )}
+          )}
+          {needsVerification && (
+            <>
+              {verifyDone ? (
+                <p className="rounded-lg border border-success/20 bg-success/10 px-3 py-2 text-[13px] text-success">
+                  Email envoyé ! Vérifiez votre boîte.
+                </p>
+              ) : (
+                <button
+                  onClick={() => {
+                    void handleResendVerification();
+                  }}
+                  disabled={verifying}
+                  className="inline-flex h-9 items-center justify-center rounded-[9px] border border-line bg-surface px-4 text-sm font-medium text-ink-2 transition-all hover:-translate-y-0.5 hover:border-ink hover:text-ink disabled:opacity-50"
+                >
+                  {verifying ? 'Envoi…' : 'Vérifier mon compte'}
+                </button>
+              )}
+              {verifyError !== null && (
+                <p className="max-w-[220px] rounded-lg border border-danger/20 bg-danger/10 px-3 py-2 text-[12px] text-danger">
+                  {verifyError}
+                </p>
+              )}
+            </>
+          )}
+        </div>
       </div>
     </div>
   );
@@ -152,8 +205,9 @@ export function PersonPage() {
   }
 
   const color = promoColor(person.startYear);
-  const canEdit =
-    user !== null && user.isValidated && (user.isAdmin || user.person.id === person.id);
+  const isOwnProfile = user !== null && user.person.id === person.id;
+  const canEdit = isOwnProfile && (user.isValidated || user.isAdmin);
+  const needsVerification = isOwnProfile && !user.isValidated && !user.isAdmin;
   const visibleCharacteristics = person.characteristics.filter((c) => c.visible && c.value);
   const allSponsors = [...person.godFathers, ...person.godChildren];
   return (
@@ -167,7 +221,7 @@ export function PersonPage() {
           className="mb-6"
         />
 
-        <PersonHero person={person} canEdit={canEdit} />
+        <PersonHero person={person} canEdit={canEdit} needsVerification={needsVerification} />
 
         {/* Stats */}
         <div className="mb-5 grid grid-cols-3 gap-3">

--- a/frontend/src/types/auth.ts
+++ b/frontend/src/types/auth.ts
@@ -30,5 +30,4 @@ export interface AvailablePerson {
   lastName: string;
   fullName: string;
   startYear: number;
-  color: string;
 }


### PR DESCRIPTION
- Fix crash on SelectPersonPage: person.color was never returned by the
  backend; switch to promoColor(startYear) + remove color from AvailablePerson type
- Add React ErrorBoundary wrapping the whole app, showing a friendly
  "contact an admin" page instead of a raw crash screen
- Backend: add POST /api/auth/resend-verification (auth required) so an
  unverified user can request a new verification email from their profile
- Backend: simplify password-reset flow — instead of a token/confirm link,
  generate a random 12-char password, set it immediately, and email it to
  the user so they can log in and change it from their profile
- Frontend PersonPage: show "Vérifier mon compte" button when the logged-in
  user is viewing their own profile and their account is not yet validated
- Frontend ResetPasswordPage: remove the now-unused token-confirm step;
  the form only asks for an email and shows a success message on submission

https://claude.ai/code/session_017gz649daTrEbzVZKPv41kS