### PR TITLE
feat(admin): add test mail button on dashboard

### DIFF
--- a/backend/src/Controller/Admin/DashboardController.php
+++ b/backend/src/Controller/Admin/DashboardController.php
@@ -26,7 +26,7 @@ final class DashboardController extends AbstractDashboardController
     #[\Override]
     public function index(): Response
     {
-        return $this->render('@EasyAdmin/page/content.html.twig');
+        return $this->render('admin/dashboard.html.twig');
     }
 
     #[\Override]
@@ -50,6 +50,8 @@ final class DashboardController extends AbstractDashboardController
         yield MenuItem::linkTo(SponsorCrudController::class, 'Parrainages', 'fa fa-link');
         yield MenuItem::section('Demandes');
         yield MenuItem::linkTo(ContactCrudController::class, 'Contacts', 'fa fa-envelope');
+        yield MenuItem::section('Outils');
+        yield MenuItem::linkToUrl('Test mail', 'fa fa-paper-plane', $this->adminUrlGenerator->setRoute('admin_test_mail')->generateUrl());
         yield MenuItem::section();
         yield MenuItem::linkToUrl('Retour au site', 'fa fa-arrow-left', '/');
     }

--- a/backend/src/Controller/Admin/TestMailAdminController.php
+++ b/backend/src/Controller/Admin/TestMailAdminController.php
@@ -1,0 +1,75 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Controller\Admin;
+
+use App\Entity\Person\Role;
+use EasyCorp\Bundle\EasyAdminBundle\Router\AdminUrlGenerator;
+use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
+use Symfony\Component\HttpFoundation\RedirectResponse;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\Mailer\Exception\TransportExceptionInterface;
+use Symfony\Component\Mailer\MailerInterface;
+use Symfony\Component\Mime\Address;
+use Symfony\Component\Mime\Email;
+use Symfony\Component\Routing\Attribute\Route;
+use Symfony\Component\Security\Http\Attribute\IsGranted;
+
+#[IsGranted(Role::ADMIN->value)]
+final class TestMailAdminController extends AbstractController
+{
+    public function __construct(
+        private readonly MailerInterface $mailer,
+        private readonly AdminUrlGenerator $adminUrlGenerator,
+        private readonly string $mailUser,
+        private readonly string $mailName,
+    ) {
+    }
+
+    #[Route('/admin/test-mail', name: 'admin_test_mail', methods: ['GET', 'POST'])]
+    public function index(Request $request): Response
+    {
+        if ($request->isMethod('POST')) {
+            return $this->handleSend($request);
+        }
+
+        return $this->render('admin/test_mail.html.twig');
+    }
+
+    private function handleSend(Request $request): RedirectResponse
+    {
+        $origin      = $request->request->getString('_origin');
+        $redirectUrl = $origin === 'dashboard'
+            ? $this->adminUrlGenerator->setRoute('admin')->generateUrl()
+            : $this->adminUrlGenerator->setRoute('admin_test_mail')->generateUrl();
+
+        if (!$this->isCsrfTokenValid('test_mail', $request->request->getString('_token'))) {
+            $this->addFlash('danger', 'Token CSRF invalide.');
+            return $this->redirect($redirectUrl);
+        }
+
+        $recipient = trim($request->request->getString('email'));
+
+        if ($recipient === '' || filter_var($recipient, FILTER_VALIDATE_EMAIL) === false) {
+            $this->addFlash('danger', 'Adresse email invalide.');
+            return $this->redirect($redirectUrl);
+        }
+
+        $email = new Email()
+            ->from(new Address($this->mailUser, $this->mailName))
+            ->to($recipient)
+            ->subject('[Parraindex] Email de test')
+            ->html('<p>Ceci est un email de test envoyé depuis le tableau de bord Parraindex. Si vous recevez ce message, l\'envoi d\'emails fonctionne correctement.</p>');
+
+        try {
+            $this->mailer->send($email);
+            $this->addFlash('success', sprintf('Email de test envoyé avec succès à %s.', $recipient));
+        } catch (TransportExceptionInterface $transportException) {
+            $this->addFlash('danger', sprintf('Échec de l\'envoi : %s', $transportException->getMessage()));
+        }
+
+        return $this->redirect($redirectUrl);
+    }
+}

--- a/backend/templates/admin/dashboard.html.twig
+++ b/backend/templates/admin/dashboard.html.twig
@@ -1,0 +1,49 @@
+{% extends '@EasyAdmin/page/content.html.twig' %}
+
+{% block page_title %}Tableau de bord{% endblock %}
+
+{% block content %}
+<div class="row g-4">
+    <div class="col-12 col-lg-6">
+        {% for message in app.flashes('success') %}
+            <div class="alert alert-success">
+                <i class="fa fa-check-circle me-1"></i> {{ message }}
+            </div>
+        {% endfor %}
+        {% for message in app.flashes('danger') %}
+            <div class="alert alert-danger">
+                <i class="fa fa-times-circle me-1"></i> {{ message }}
+            </div>
+        {% endfor %}
+
+        <div class="card">
+            <div class="card-header">
+                <h5 class="card-title mb-0">
+                    <i class="fa fa-paper-plane me-2"></i>Test d'envoi d'email
+                </h5>
+            </div>
+            <div class="card-body">
+                <p class="text-muted">
+                    Vérifiez que la configuration SMTP fonctionne en envoyant un email de test.
+                </p>
+                <form method="post" action="{{ path('admin_test_mail') }}">
+                    <input type="hidden" name="_token" value="{{ csrf_token('test_mail') }}">
+                    <input type="hidden" name="_origin" value="dashboard">
+                    <div class="input-group">
+                        <input
+                            type="email"
+                            class="form-control"
+                            name="email"
+                            placeholder="destinataire@exemple.fr"
+                            required
+                        >
+                        <button type="submit" class="btn btn-primary">
+                            <i class="fa fa-paper-plane me-1"></i> Envoyer
+                        </button>
+                    </div>
+                </form>
+            </div>
+        </div>
+    </div>
+</div>
+{% endblock %}

--- a/backend/templates/admin/test_mail.html.twig
+++ b/backend/templates/admin/test_mail.html.twig
@@ -1,0 +1,49 @@
+{% extends '@EasyAdmin/page/content.html.twig' %}
+
+{% block page_title %}Test d'envoi d'email{% endblock %}
+
+{% block content %}
+<div class="row">
+    <div class="col-12 col-lg-6">
+        {% for message in app.flashes('success') %}
+            <div class="alert alert-success">
+                <i class="fa fa-check-circle me-1"></i> {{ message }}
+            </div>
+        {% endfor %}
+        {% for message in app.flashes('danger') %}
+            <div class="alert alert-danger">
+                <i class="fa fa-times-circle me-1"></i> {{ message }}
+            </div>
+        {% endfor %}
+
+        <div class="card">
+            <div class="card-header">
+                <h5 class="card-title mb-0">Envoyer un email de test</h5>
+            </div>
+            <div class="card-body">
+                <p class="text-muted">
+                    Envoyez un email de test pour vérifier que la configuration SMTP fonctionne correctement.
+                </p>
+                <form method="post" action="{{ path('admin_test_mail') }}">
+                    <input type="hidden" name="_token" value="{{ csrf_token('test_mail') }}">
+                    <div class="mb-3">
+                        <label for="test_mail_email" class="form-label fw-bold">Adresse email destinataire</label>
+                        <input
+                            type="email"
+                            class="form-control"
+                            id="test_mail_email"
+                            name="email"
+                            placeholder="exemple@domaine.fr"
+                            required
+                            autofocus
+                        >
+                    </div>
+                    <button type="submit" class="btn btn-primary">
+                        <i class="fa fa-paper-plane me-1"></i> Envoyer l'email de test
+                    </button>
+                </form>
+            </div>
+        </div>
+    </div>
+</div>
+{% endblock %}


### PR DESCRIPTION
Adds a test email form on the EasyAdmin dashboard homepage and a dedicated
/admin/test-mail page to verify SMTP configuration from the admin panel.

https://claude.ai/code/session_01LVzHcWyp1rAXVhFaAbwMBp