### PR TITLE
feat: ajouter le type de parrainage FALUCHE

### DIFF
--- a/backend/CLAUDE.md
+++ b/backend/CLAUDE.md
@@ -92,7 +92,7 @@ composer scss:build          # Compiler SCSS et assets
 
 **Sponsor** - Relation de parrainage
 - `godFather` → `godChild`
-- `type`: HEART (0), CLASSIC (1), UNKNOWN (2)
+- `type`: HEART (0), CLASSIC (1), UNKNOWN (2), FALUCHE (3)
 
 **Contact** - Demande utilisateur
 - Types: ADD_PERSON, UPDATE_PERSON, REMOVE_PERSON, ADD_SPONSOR, etc.

--- a/backend/src/Controller/Admin/Crud/SponsorCrudController.php
+++ b/backend/src/Controller/Admin/Crud/SponsorCrudController.php
@@ -80,6 +80,7 @@ final class SponsorCrudController extends AbstractCrudController
                 'Parrainage de cœur' => Type::HEART,
                 'Parrainage IUT'     => Type::CLASSIC,
                 'Inconnu'            => Type::UNKNOWN,
+                'Faluche'            => Type::FALUCHE,
             ]);
         yield DateField::new('date', 'Date')->hideOnIndex();
         yield TextareaField::new('description', 'Description')->hideOnIndex();

--- a/backend/src/Dto/Sponsor/SponsorTypeDto.php
+++ b/backend/src/Dto/Sponsor/SponsorTypeDto.php
@@ -11,13 +11,15 @@ enum SponsorTypeDto: string
     case HEART   = 'HEART';
     case CLASSIC = 'CLASSIC';
     case UNKNOWN = 'UNKNOWN';
+    case FALUCHE = 'FALUCHE';
 
     public function toEntity(): Type
     {
         return match ($this) {
-            self::HEART   => Type::HEART,
-            self::CLASSIC => Type::CLASSIC,
-            self::UNKNOWN => Type::UNKNOWN,
+            self::HEART    => Type::HEART,
+            self::CLASSIC  => Type::CLASSIC,
+            self::UNKNOWN  => Type::UNKNOWN,
+            self::FALUCHE  => Type::FALUCHE,
         };
     }
 }

--- a/backend/src/Entity/Sponsor/Type.php
+++ b/backend/src/Entity/Sponsor/Type.php
@@ -9,13 +9,15 @@ enum Type: int
     case HEART   = 0;
     case CLASSIC = 1;
     case UNKNOWN = 2;
+    case FALUCHE = 3;
 
     public function getTitle(): string
     {
         return match ($this) {
-            self::HEART   => 'Parrainage de coeur',
-            self::CLASSIC => 'Parrainage IUT',
-            self::UNKNOWN => 'Inconnu',
+            self::HEART    => 'Parrainage de coeur',
+            self::CLASSIC  => 'Parrainage IUT',
+            self::UNKNOWN  => 'Inconnu',
+            self::FALUCHE  => 'Faluche',
         };
     }
 
@@ -25,18 +27,20 @@ enum Type: int
     public static function allTitles(): array
     {
         return [
-            self::HEART->value   => 'Parrainage de coeur',
-            self::CLASSIC->value => 'Parrainage IUT',
-            self::UNKNOWN->value => 'Inconnu',
+            self::HEART->value    => 'Parrainage de coeur',
+            self::CLASSIC->value  => 'Parrainage IUT',
+            self::UNKNOWN->value  => 'Inconnu',
+            self::FALUCHE->value  => 'Faluche',
         ];
     }
 
     public function getIcon(): string
     {
         return match ($this) {
-            self::HEART   => 'heart.svg',
-            self::CLASSIC => 'chain.svg',
-            self::UNKNOWN => 'interrogation.svg',
+            self::HEART    => 'heart.svg',
+            self::CLASSIC  => 'chain.svg',
+            self::UNKNOWN  => 'interrogation.svg',
+            self::FALUCHE  => 'faluche.svg',
         };
     }
 }

--- a/backend/src/Service/CsvImportService.php
+++ b/backend/src/Service/CsvImportService.php
@@ -284,6 +284,7 @@ final readonly class CsvImportService
         return match (strtoupper(trim($type))) {
             'HEART'   => SponsorType::HEART,
             'CLASSIC' => SponsorType::CLASSIC,
+            'FALUCHE' => SponsorType::FALUCHE,
             default   => SponsorType::UNKNOWN,
         };
     }

--- a/backend/tests/Unit/Entity/Sponsor/TypeTest.php
+++ b/backend/tests/Unit/Entity/Sponsor/TypeTest.php
@@ -81,18 +81,44 @@ final class TypeTest extends TestCase
         $this->assertSame('interrogation.svg', $result);
     }
 
-    public function testAllTitlesReturnsAssociativeArrayWithThreeEntries(): void
+    public function testGetTitleReturnsCorrectTitleForFaluche(): void
+    {
+        // Given
+        $type = Type::FALUCHE;
+
+        // When
+        $result = $type->getTitle();
+
+        // Then
+        $this->assertSame('Faluche', $result);
+    }
+
+    public function testGetIconReturnsCorrectIconForFaluche(): void
+    {
+        // Given
+        $type = Type::FALUCHE;
+
+        // When
+        $result = $type->getIcon();
+
+        // Then
+        $this->assertSame('faluche.svg', $result);
+    }
+
+    public function testAllTitlesReturnsAssociativeArrayWithFourEntries(): void
     {
         // Given & When
         $result = Type::allTitles();
 
         // Then
-        $this->assertCount(3, $result);
+        $this->assertCount(4, $result);
         $this->assertArrayHasKey(0, $result); // HEART
         $this->assertArrayHasKey(1, $result); // CLASSIC
         $this->assertArrayHasKey(2, $result); // UNKNOWN
+        $this->assertArrayHasKey(3, $result); // FALUCHE
         $this->assertSame('Parrainage de coeur', $result[0]);
         $this->assertSame('Parrainage IUT', $result[1]);
         $this->assertSame('Inconnu', $result[2]);
+        $this->assertSame('Faluche', $result[3]);
     }
 }

--- a/frontend/src/lib/sponsorTypes.ts
+++ b/frontend/src/lib/sponsorTypes.ts
@@ -4,10 +4,12 @@ export const SPONSOR_TYPE_ICONS: Record<SponsorType, string> = {
   HEART: '♥',
   CLASSIC: '⚒︎',
   UNKNOWN: '?',
+  FALUCHE: '🎓',
 };
 
 export const SPONSOR_TYPE_LABELS: Record<SponsorType, string> = {
   HEART: 'de cœur',
   CLASSIC: 'IUT',
   UNKNOWN: 'inconnu',
+  FALUCHE: 'Faluche',
 };

--- a/frontend/src/lib/sponsorTypes.ts
+++ b/frontend/src/lib/sponsorTypes.ts
@@ -4,12 +4,12 @@ export const SPONSOR_TYPE_ICONS: Record<SponsorType, string> = {
   HEART: '♥',
   CLASSIC: '⚒︎',
   UNKNOWN: '?',
-  FALUCHE: '🎓',
+  FALUCHE: '🎩',
 };
 
 export const SPONSOR_TYPE_LABELS: Record<SponsorType, string> = {
   HEART: 'de cœur',
   CLASSIC: 'IUT',
   UNKNOWN: 'inconnu',
-  FALUCHE: 'Faluche',
+  FALUCHE: 'faluchard',
 };

--- a/frontend/src/pages/person/EditPersonPage.tsx
+++ b/frontend/src/pages/person/EditPersonPage.tsx
@@ -213,7 +213,7 @@ function AddSponsorForm({
   const TYPE_OPTIONS: { value: SponsorType; label: string }[] = [
     { value: 'CLASSIC', label: 'IUT' },
     { value: 'HEART', label: 'De cœur' },
-    { value: 'FALUCHE', label: 'Faluche' },
+    { value: 'FALUCHE', label: 'Faluchard' },
     { value: 'UNKNOWN', label: 'Inconnu' },
   ];
 
@@ -354,7 +354,7 @@ function SponsorRow({
   const TYPE_OPTIONS: { value: SponsorType; label: string }[] = [
     { value: 'CLASSIC', label: 'IUT' },
     { value: 'HEART', label: 'De cœur' },
-    { value: 'FALUCHE', label: 'Faluche' },
+    { value: 'FALUCHE', label: 'Faluchard' },
     { value: 'UNKNOWN', label: 'Inconnu' },
   ];
 

--- a/frontend/src/pages/person/EditPersonPage.tsx
+++ b/frontend/src/pages/person/EditPersonPage.tsx
@@ -213,6 +213,7 @@ function AddSponsorForm({
   const TYPE_OPTIONS: { value: SponsorType; label: string }[] = [
     { value: 'CLASSIC', label: 'IUT' },
     { value: 'HEART', label: 'De cœur' },
+    { value: 'FALUCHE', label: 'Faluche' },
     { value: 'UNKNOWN', label: 'Inconnu' },
   ];
 
@@ -353,6 +354,7 @@ function SponsorRow({
   const TYPE_OPTIONS: { value: SponsorType; label: string }[] = [
     { value: 'CLASSIC', label: 'IUT' },
     { value: 'HEART', label: 'De cœur' },
+    { value: 'FALUCHE', label: 'Faluche' },
     { value: 'UNKNOWN', label: 'Inconnu' },
   ];
 

--- a/frontend/src/types/sponsor.ts
+++ b/frontend/src/types/sponsor.ts
@@ -1,4 +1,4 @@
-export type SponsorType = 'HEART' | 'CLASSIC' | 'UNKNOWN';
+export type SponsorType = 'HEART' | 'CLASSIC' | 'UNKNOWN' | 'FALUCHE';
 
 export interface Sponsor {
   id: number;


### PR DESCRIPTION
Nouveau type FALUCHE (valeur 3) dans le back PHP et le front React.
Icône 🎓 côté frontend, faluche.svg côté backend.

Fichiers modifiés :
- Entity Sponsor/Type : case FALUCHE = 3, getTitle/getIcon/allTitles
- Dto SponsorTypeDto : case FALUCHE + mapping toEntity
- SponsorCrudController : choix 'Faluche' dans l'admin EasyAdmin
- CsvImportService : 'FALUCHE' reconnu dans parseSponsorType
- TypeTest : 2 nouveaux tests + allTitles mis à jour (4 entrées)
- CLAUDE.md backend : doc du champ type mise à jour
- types/sponsor.ts : union étendue à 'FALUCHE'
- lib/sponsorTypes.ts : icône 🎓 et label 'Faluche'
- EditPersonPage.tsx : option Faluche dans TYPE_OPTIONS (×2)

https://claude.ai/code/session_01GyA3YsZYajam5cZMw6RzPL