### PR TITLE
Make password optional in EasyAdmin user edit form

### DIFF
--- a/backend/src/Controller/Admin/Crud/UserCrudController.php
+++ b/backend/src/Controller/Admin/Crud/UserCrudController.php
@@ -17,6 +17,7 @@ use EasyCorp\Bundle\EasyAdminBundle\Field\IdField;
 use EasyCorp\Bundle\EasyAdminBundle\Field\TextField;
 use Symfony\Component\Form\Extension\Core\Type\PasswordType;
 use Symfony\Component\PasswordHasher\Hasher\UserPasswordHasherInterface;
+use Symfony\Component\Validator\Constraints\NotBlank;
 
 /** @extends AbstractCrudController<User> */
 final class UserCrudController extends AbstractCrudController
@@ -53,9 +54,10 @@ final class UserCrudController extends AbstractCrudController
                     return Role::from($r);
                 }, $roles)
             ));
-        yield TextField::new('password', 'Mot de passe')
+        yield TextField::new('plainPassword', 'Mot de passe')
             ->setFormType(PasswordType::class)
-            ->setFormTypeOption('empty_data', '')
+            ->setFormTypeOption('empty_data', null)
+            ->setFormTypeOption('constraints', $pageName === 'new' ? [new NotBlank(message: 'Le mot de passe est requis')] : [])
             ->setRequired($pageName === 'new')
             ->hideOnIndex()
             ->hideOnDetail()
@@ -84,7 +86,7 @@ final class UserCrudController extends AbstractCrudController
             return;
         }
 
-        $plain = $entityInstance->getPassword();
+        $plain = $entityInstance->getPlainPassword();
         if ($plain === null || $plain === '') {
             return;
         }

--- a/backend/src/Entity/Person/User.php
+++ b/backend/src/Entity/Person/User.php
@@ -37,18 +37,17 @@ class User implements UserInterface, PasswordAuthenticatedUserInterface
      * @var ?string The hashed password
      */
     #[ORM\Column]
-    #[Assert\Length(
-        min: 6,
-        max: 4096,
-        minMessage: 'Votre mot de passe doit faire au moins {{ limit }} caractères'
-    )]
-    #[Assert\NotBlank]
-    #[Assert\NotCompromisedPassword(message: 'Ce mot de passe a déjà été compromis. Veuillez en choisir un autre')]
-    #[Assert\PasswordStrength(
-        minScore: Assert\PasswordStrength::STRENGTH_WEAK,
-        message: 'Votre mot de passe est trop simple'
-    )]
     private ?string $password = null;
+
+    #[Assert\When(
+        expression: "value !== null and value !== ''",
+        constraints: [
+            new Assert\Length(min: 6, max: 4096, minMessage: 'Votre mot de passe doit faire au moins {{ limit }} caractères'),
+            new Assert\NotCompromisedPassword(message: 'Ce mot de passe a déjà été compromis. Veuillez en choisir un autre'),
+            new Assert\PasswordStrength(minScore: Assert\PasswordStrength::STRENGTH_WEAK, message: 'Votre mot de passe est trop simple'),
+        ]
+    )]
+    private ?string $plainPassword = null;
 
     #[ORM\Column(type: Types::DATETIME_IMMUTABLE)]
     private ?\DateTimeInterface $createdAt = null;
@@ -147,6 +146,18 @@ class User implements UserInterface, PasswordAuthenticatedUserInterface
     public function setPassword(string $password): static
     {
         $this->password = $password;
+
+        return $this;
+    }
+
+    public function getPlainPassword(): ?string
+    {
+        return $this->plainPassword;
+    }
+
+    public function setPlainPassword(?string $plainPassword): static
+    {
+        $this->plainPassword = $plainPassword;
 
         return $this;
     }


### PR DESCRIPTION
Introduce a non-persisted `plainPassword` field on User entity so the
admin can modify roles or other fields without re-entering a password.
Password strength constraints are moved to `plainPassword` via
`Assert\When` (only validated when a value is provided), and the CRUD
controller enforces `NotBlank` only on the creation form.

https://claude.ai/code/session_01KS87wGPgQM6XW2aZ9geV7s