### PR TITLE
Add missing api_admin_persons_import_template route for CSV template download

### DIFF
--- a/backend/src/Controller/Admin/CsvImportAdminController.php
+++ b/backend/src/Controller/Admin/CsvImportAdminController.php
@@ -29,31 +29,14 @@ final class CsvImportAdminController extends AbstractController
     #[Route('/admin/persons/import/template', name: 'api_admin_persons_import_template', methods: ['GET'])]
     public function downloadTemplate(): StreamedResponse
     {
-        $headers = [
-            'firstName',
-            'lastName',
-            'startYear',
-            'biography',
-            'description',
-            'godFatherFirstName',
-            'godFatherLastName',
-            'sponsorType',
-            'sponsorDate',
-            'sponsorDescription',
-        ];
+        $csvContent = $this->csvImportService->generateTemplate();
 
-        $response = new StreamedResponse(function () use ($headers): void {
-            $handle = fopen('php://output', 'w');
-            if ($handle === false) {
-                return;
-            }
-            fputcsv($handle, $headers);
-            fputcsv($handle, ['Jean', 'Dupont', '2020', 'Étudiant en BUT', 'Promo 2020', 'Marie', 'Martin', 'CLASSIC', '2021-09-01', 'Parrainage de promo']);
-            fclose($handle);
+        $response = new StreamedResponse(static function () use ($csvContent): void {
+            echo $csvContent;
         });
 
-        $response->headers->set('Content-Type', 'text/csv; charset=UTF-8');
-        $response->headers->set('Content-Disposition', 'attachment; filename="template_import.csv"');
+        $response->headers->set('Content-Type', 'text/csv; charset=utf-8');
+        $response->headers->set('Content-Disposition', 'attachment; filename="import_personnes_template.csv"');
 
         return $response;
     }

--- a/backend/src/Controller/Admin/CsvImportAdminController.php
+++ b/backend/src/Controller/Admin/CsvImportAdminController.php
@@ -13,6 +13,7 @@ use Symfony\Component\HttpFoundation\Session\FlashBagAwareSessionInterface;
 use Symfony\Component\HttpFoundation\File\UploadedFile;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\HttpFoundation\StreamedResponse;
 use Symfony\Component\Routing\Attribute\Route;
 use Symfony\Component\Security\Http\Attribute\IsGranted;
 
@@ -23,6 +24,38 @@ final class CsvImportAdminController extends AbstractController
         private readonly CsvImportService $csvImportService,
         private readonly AdminUrlGenerator $adminUrlGenerator,
     ) {
+    }
+
+    #[Route('/admin/persons/import/template', name: 'api_admin_persons_import_template', methods: ['GET'])]
+    public function downloadTemplate(): StreamedResponse
+    {
+        $headers = [
+            'firstName',
+            'lastName',
+            'startYear',
+            'biography',
+            'description',
+            'godFatherFirstName',
+            'godFatherLastName',
+            'sponsorType',
+            'sponsorDate',
+            'sponsorDescription',
+        ];
+
+        $response = new StreamedResponse(function () use ($headers): void {
+            $handle = fopen('php://output', 'w');
+            if ($handle === false) {
+                return;
+            }
+            fputcsv($handle, $headers);
+            fputcsv($handle, ['Jean', 'Dupont', '2020', 'Étudiant en BUT', 'Promo 2020', 'Marie', 'Martin', 'CLASSIC', '2021-09-01', 'Parrainage de promo']);
+            fclose($handle);
+        });
+
+        $response->headers->set('Content-Type', 'text/csv; charset=UTF-8');
+        $response->headers->set('Content-Disposition', 'attachment; filename="template_import.csv"');
+
+        return $response;
     }
 
     #[Route('/admin/persons/import', name: 'admin_csv_import', methods: ['GET', 'POST'])]


### PR DESCRIPTION
The csv_import.html.twig template referenced this route at line 38 but the
corresponding controller action did not exist, causing a RouteNotFoundException
on the admin CSV import page.

https://claude.ai/code/session_01E42YH6wfyDywb2exrYgcMG