### PR TITLE
Fix Sponsor created_at NOT NULL violation when created via EasyAdmin

### DIFF
--- a/backend/src/Entity/Sponsor/Sponsor.php
+++ b/backend/src/Entity/Sponsor/Sponsor.php
@@ -38,7 +38,12 @@ class Sponsor implements \Stringable
     private ?Type $type = null;
 
     #[ORM\Column(type: Types::DATETIME_MUTABLE)]
-    private ?\DateTimeInterface $createdAt = null;
+    private \DateTimeInterface $createdAt;
+
+    public function __construct()
+    {
+        $this->createdAt = new \DateTime();
+    }
 
     public function getId(): ?int
     {
@@ -112,12 +117,12 @@ class Sponsor implements \Stringable
         return $this;
     }
 
-    public function getCreatedAt(): ?\DateTimeInterface
+    public function getCreatedAt(): \DateTimeInterface
     {
         return $this->createdAt;
     }
 
-    public function setCreatedAt(?\DateTimeInterface $createdAt): static
+    public function setCreatedAt(\DateTimeInterface $createdAt): static
     {
         $this->createdAt = $createdAt;
 

--- a/backend/src/Repository/SponsorRepository.php
+++ b/backend/src/Repository/SponsorRepository.php
@@ -39,10 +39,6 @@ class SponsorRepository extends ServiceEntityRepository
 
     public function update(Sponsor $sponsor): void
     {
-        if (!$sponsor->getCreatedAt() instanceof \DateTimeInterface) {
-            $sponsor->setCreatedAt(new \DateTime());
-        }
-
         if (!$sponsor->getType() instanceof Type) {
             $sponsor->setType(Type::UNKNOWN);
         }

--- a/backend/tests/Integration/Repository/SponsorRepositoryTest.php
+++ b/backend/tests/Integration/Repository/SponsorRepositoryTest.php
@@ -110,7 +110,7 @@ final class SponsorRepositoryTest extends KernelTestCase
         $this->repository->create($sponsor);
 
         // Then
-        $this->assertInstanceOf(\DateTimeInterface::class, $sponsor->getCreatedAt());
+        $this->assertEqualsWithDelta(time(), $sponsor->getCreatedAt()->getTimestamp(), 5);
     }
 
     public function testCreateSetsDefaultTypeWhenNull(): void


### PR DESCRIPTION
EasyAdmin bypasses the repository's update() method, so createdAt was
never set before persist. Initialize it in the constructor instead.

https://claude.ai/code/session_01L7PAqtm4u2Pa9k2TBj1jpw